### PR TITLE
fix: department selection duplicating

### DIFF
--- a/ui/script.js
+++ b/ui/script.js
@@ -190,6 +190,7 @@ window.addEventListener("message", function(event) {
     }
 
     if (item.type === "givePerms") {
+        $(".departments").empty();
         JSON.parse(item.deptRoles).forEach((job) => {
             $(".departments").append($("<option>", {
                 text: job


### PR DESCRIPTION
fixes #3
empties the department selection box each time givePerms is run to prevent the departments from duplicating