### PR TITLE
Salary by rank additions

### DIFF
--- a/data/salaries.lua
+++ b/data/salaries.lua
@@ -1,27 +1,125 @@
 return {
     ["default"] = { -- default salary characters receive with none of these jobs.
         enabled = true,
-        interval = 24,
-        amount = 300
+        interval = 15,
+        amount = 300,
+        rank = {
+            [1] = 50
+        }
     },
-    ["sahp"] = {
+    ["sasp"] = {
         enabled = true,
-        interval = 24,
-        amount = 700
+        interval = 15,
+        amount = 500,
+        rank = {
+            [1] = 325,
+            [2] = 450,
+        }
     },
-    ["lspd"] = {
+    ["police"] = {
         enabled = true,
-        interval = 24,
-        amount = 600
+        interval = 15,
+        amount = 500,
+        rank = {
+            [1] = 325,
+            [2] = 375,
+            [3] = 400,
+            [4] = 460,
+            [5] = 525,
+            [6] = 545,
+            [7] = 600,
+            [8] = 625,
+            [9] = 700,
+            [10] = 800,
+        }
     },
     ["bcso"] = {
         enabled = true,
-        interval = 24,
-        amount = 500
+        interval = 15,
+        amount = 500,
+        rank = {
+            [1] = 325,
+            [2] = 375,
+            [3] = 400,
+            [4] = 460,
+            [5] = 525,
+            [6] = 545,
+            [7] = 600,
+            [8] = 625,
+            [9] = 700,
+            [10] = 800,
+        }
+    },
+    ["doc"] = {
+        enabled = true,
+        interval = 15,
+        amount = 500,
+        rank = {
+            [1] = 325,
+            [2] = 375,
+            [3] = 400,
+            [4] = 460,
+            [5] = 525,
+            [6] = 545,
+            [7] = 600,
+            [8] = 625,
+            [9] = 700,
+            [10] = 800,
+            [11] = 850,
+            [12] = 900,
+        }
+    },
+    ["srt"] = {
+        enabled = true,
+        interval = 15,
+        amount = 500,
+        rank = {
+            [1] = 525,
+            [2] = 545,
+            [3] = 600,
+            [4] = 625,
+            [5] = 700,
+            [6] = 800,
+        }
     },
     ["lsfd"] = {
         enabled = true,
-        interval = 24,
-        amount = 800
+        interval = 15,
+        amount = 800,
+        rank = {
+            [1] = 225,
+            [2] = 345,
+            [3] = 400,
+            [4] = 525,
+            [5] = 600,
+            [6] = 1000,
+        }
+    },
+    ["sams"] = {
+        enabled = true,
+        interval = 15,
+        amount = 800,
+        rank = {
+            [1] = 425,
+            [2] = 545,
+            [3] = 600,
+            [4] = 725,
+            [5] = 875,
+            [6] = 900,
+        }
+    },
+    ["doj"] = {
+        enabled = true,
+        interval = 15,
+        amount = 1200,
+        rank = {
+            [1] = 425,
+            [2] = 545,
+            [3] = 600,
+            [4] = 725,
+            [5] = 875,
+            [6] = 900,
+        }
     }
 }
+

--- a/source/server.lua
+++ b/source/server.lua
@@ -114,33 +114,29 @@ CreateThread(function()
             break
         end
     end
-
     local lastSalaryPayouts = {}
     while payChecks do
         Wait(60000)
-
         local time = os.time()
         for _, player in pairs(NDCore.getPlayers()) do
             local salaryInfo = getSalary(player) or config.salaries["default"] or config.salaries["DEFAULT"]
             local src = player.source
             local lastPayout = lastSalaryPayouts[src]
-
             if not lastPayout then
                 lastSalaryPayouts[src] = time -- this will make it to where it won't pay the player until next interval which will prevent pay if switching characters everytime.
             end
-
-            if salaryInfo and (not lastPayout or time-lastPayout > salaryInfo.interval*60) then                
-                local salary = salaryInfo.amount or 100
-                player.addMoney("bank", salary, "Salary")
-                player.notify({
-                    title = "Salary",
-                    description = ("Received $%d."):format(salary),
-                    type = "success",
-                    icon = "sack-dollar"
-                })
+            if salaryInfo and (not lastPayout or time-lastPayout > salaryInfo.interval*60) then
+                local salary = salaryInfo.rank[player.jobInfo.rank] or 100
+                player.addMoney("bank", salary, player.jobInfo.label.." Salary")
+                TriggerClientEvent('ox_lib:notify', player.source, {description = ("Recieved $%s from %s"):format(salary, player.jobInfo.label)})
                 lastSalaryPayouts[src] = time
             end
-
+            if not salaryInfo and (not lastPayout or time-lastPayout > salaryInfo.interval*60) then
+                local salary = 50
+                player.addMoney("bank", salary, "Citizen Salary")
+                TriggerClientEvent('ox_lib:notify', player.source, {description = ("Welfare Check - $%s"):format(salary, player.jobInfo.label)})
+                lastSalaryPayouts[src] = time
+            end
         end
     end
 end)


### PR DESCRIPTION
Adjusted salaraies.lua (added couple jobs) and modified the server.lua for player payments, if they are unemployed/default then it will show as "Welfare Check", additional checks could be added if owners wish to add their own duty system such as onduty/offduty checks for the types of payments their players get.